### PR TITLE
rename document

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ archive.json
 report.xml
 venv/
 lib
-draft-gpew-priv-ppm.xml
+draft-ietf-ppm-dap.xml
 *.aux
 *.bbl
 *.blg

--- a/.note.xml
+++ b/.note.xml
@@ -3,5 +3,5 @@
     mailing list (),
   which is archived at <eref target=""/>.</t>
 <t>Source for this draft and an issue tracker can be found at
-  <eref target="https://github.com/abetterinternet/ppm-specification"/>.</t>
+  <eref target="https://github.com/ietf-wg-ppm/ppm-specification"/>.</t>
 </note>

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
 # License
 
 See the
-[guidelines for contributions](https://github.com/abetterinternet/ppm-specification/blob/i-d-format/CONTRIBUTING.md).
+[guidelines for contributions](https://github.com/ietf-wg-ppm/ppm-specification/blob/i-d-format/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 This is the working area for the individual Internet-Draft, "Privacy Preserving Measurement Protocol".
 
-* [Editor's Copy](https://ietf-wg-ppm.github.io/ppm-specification/#go.draft-gpew-priv-ppm.html)
-* [Individual Draft](https://datatracker.ietf.org/doc/html/draft-gpew-priv-ppm)
-* [Compare Editor's Copy to Individual Draft](https://ietf-wg-ppm.github.io/ppm-specification/#go.draft-gpew-priv-ppm.diff)
+* [Editor's Copy](https://ietf-wg-ppm.github.io/ppm-specification/#go.draft-ietf-ppm-dap.html)
+* [Individual Draft](https://datatracker.ietf.org/doc/html/draft-ietf-ppm-dap)
+* [Compare Editor's Copy to Individual Draft](https://ietf-wg-ppm.github.io/ppm-specification/#go.draft-ietf-ppm-dap.diff)
 
 ## Building the Draft
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Privacy Preserving Measurement Protocol
+# Distributed Aggregation Protocol for Privacy Preserving Measurement
 
-This is the working area for the individual Internet-Draft, "Privacy Preserving Measurement Protocol".
+This is the working area for the individual Internet-Draft, "Distributed Aggregation Protocol for Privacy Preserving Measurement".
 
 * [Editor's Copy](https://ietf-wg-ppm.github.io/ppm-specification/#go.draft-ietf-ppm-dap.html)
 * [Individual Draft](https://datatracker.ietf.org/doc/html/draft-ietf-ppm-dap)

--- a/charter.md
+++ b/charter.md
@@ -37,4 +37,4 @@ exposure of individual user measurements and denial of service attacks on the
 measurement system. The resulting documents shall clearly describe abuse cases
 and remaining attacks which are not prevented or mitigated by the protocol.
 
-The starting point for PPM WG discussions shall be draft-gpew-priv-ppm.
+The starting point for PPM WG discussions shall be draft-ietf-ppm-dap.

--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -1,6 +1,6 @@
 ---
 title: "Privacy Preserving Measurement"
-docname: draft-gpew-priv-ppm-latest
+docname: draft-ietf-ppm-dap-latest
 category: std
 ipr: trust200902
 area: SEC
@@ -255,7 +255,7 @@ The overall system architecture is shown in {{pa-topology}}.
 {: #pa-topology title="System Architecture"}
 
 [[OPEN ISSUE: This shows two helpers, but the document only allows one for now.
-https://github.com/abetterinternet/ppm-specification/issues/117]]
+https://github.com/ietf-wg-ppm/ppm-specification/issues/117]]
 
 
 The main participants in the protocol are as follows:
@@ -1714,7 +1714,7 @@ the protocol runs do not agree, then participants know that at least one
 aggregator is defective, and it may be possible to identify the defector (i.e.,
 if a majority of runs agree, and a single aggregator appears in every run that
 disagrees). See
-[#22](https://github.com/abetterinternet/ppm-specification/issues/22) for
+[#22](https://github.com/ietf-wg-ppm/ppm-specification/issues/22) for
 discussion.
 
 ## Infrastructure diversity

--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -1,5 +1,5 @@
 ---
-title: "Privacy Preserving Measurement"
+title: "Distributed Aggregation Protocol for Privacy Preserving Measurement"
 docname: draft-ietf-ppm-dap-latest
 category: std
 ipr: trust200902
@@ -88,20 +88,21 @@ measurement is usually not interested in people's individual responses but
 rather in aggregated data. Conventional methods require collecting individual
 responses and then aggregating them, thus representing a threat to user privacy
 and rendering many such measurements difficult and impractical. This document
-describes a multi-party privacy preserving measurement (PPM) protocol which can
-be used to collect aggregate data without revealing any individual user's data.
+describes a multi-party distributed aggregation protocol (DAP) for privacy
+preserving measurement (PPM) which can be used to collect aggregate data without
+revealing any individual user's data.
 
 --- middle
 
 # Introduction
 
-This document describes a protocol for privacy preserving measurement. The
-protocol is executed by a large set of clients and a small set of servers. The
-servers' goal is to compute some aggregate statistic over the clients' inputs
-without learning the inputs themselves. This is made possible by distributing
-the computation among the servers in such a way that, as long as at least one of
-them executes the protocol honestly, no input is ever seen in the clear by any
-server.
+This document describes a distributed aggregation protocol for privacy
+preserving measurement. The protocol is executed by a large set of clients and a
+small set of servers. The servers' goal is to compute some aggregate statistic
+over the clients' inputs without learning the inputs themselves. This is made
+possible by distributing the computation among the servers in such a way that,
+as long as at least one of them executes the protocol honestly, no input is ever
+seen in the clear by any server.
 
 ## DISCLAIMER
 

--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -1,5 +1,6 @@
 ---
 title: "Distributed Aggregation Protocol for Privacy Preserving Measurement"
+abbrev: DAP-PPM
 docname: draft-ietf-ppm-dap-latest
 category: std
 ipr: trust200902


### PR DESCRIPTION
The draft has been adopted by the WG and now needs a new name.
Additionally, this commit replaces references to the old repository on
`abetterinternet` with the current GitHub organization.