### PR TITLE
Add VDAF mapping for aggregation flow

### DIFF
--- a/draft-gpew-priv-ppm.md
+++ b/draft-gpew-priv-ppm.md
@@ -984,18 +984,18 @@ parameters except its own, the leader sends a POST request to
 `[aggregator]/aggregate` with AggregateContinueReq as the payload and the media
 type set to "message/ppm-aggregate-continue-req".
 
-For each PrepareShare in AggregateContinueReq.process_shares received from the leader, the helper
-proceeds as follows:
+For each PrepareShare in AggregateContinueReq.process_shares received from the leader,
+the helper performs the following check to determine if the report share should continue
+being prepared.
 
 * If failed, then mark the report as failed and reply with a failed PrepareShare
   to the leader.
 * If finished, then mark the report as finished and reply with a finished PrepareShare
   to the leader. The helper then moves to the completion phase of aggregation;
   see {{agg-complete}}.
-* If continued, then generate a new VDAF state and output message based on the leader's
-  message and reply with a continued PrepareShare to the leader.
 
-The helper computes its update state and output message as follows:
+Otherwise, preparation continues. In this case, the helper computes its updated state
+and output message as follows:
 
 ~~~
 out = VDAF.prep_next(prep_state, inbound)

--- a/draft-gpew-priv-ppm.md
+++ b/draft-gpew-priv-ppm.md
@@ -885,7 +885,7 @@ error `hpke-decrypt-error`. Otherwise, it outputs the resulting `input_share`.
 #### Input Share Validation {#input-share-batch-validation}
 
 Validating an input share will either succeed or fail. In the case of failure,
-the input share is marked as invalid with a ReportShareError of type `vdaf-prep-error`.
+the input share is marked as invalid with a corresponding ReportShareError error.
 
 The validation checks are as follows.
 

--- a/draft-gpew-priv-ppm.md
+++ b/draft-gpew-priv-ppm.md
@@ -759,7 +759,7 @@ shares as follows:
 
 1. Decrypt the input share for each report share as described in {{input-share-decryption}}.
 1. Check that the resulting input share is valid as described in {{input-share-batch-validation}}.
-1. Initialize VDAF preparation and initial outputs as described in {{input-share-prep}}.
+1. Initialize VDAF preparation as described in {{input-share-prep}}.
 
 If any step yields yields an invalid report share, the leader removes the report share from
 the set of candidate reports. Once the leader has initialized this state for all valid

--- a/draft-gpew-priv-ppm.md
+++ b/draft-gpew-priv-ppm.md
@@ -1019,7 +1019,7 @@ struct {
 } AggregateContinueResp;
 ~~~
 
-The order of AggregateContinueResp.prepare_shares matches that of the PrepareStep values in
+The order of AggregateContinueResp.prepare_shares MUST match that of the PrepareStep values in
 `AggregateContinueReq.prepare_shares`. The helper's response to the leader is an HTTP 200 OK whose body
 is the AggregateContinueResp and media type is "message/ppm-aggregate-continue-resp". The helper
 then awaits the next message from the leader.

--- a/draft-gpew-priv-ppm.md
+++ b/draft-gpew-priv-ppm.md
@@ -377,6 +377,7 @@ in the "type" field (within the PPM URN namespace "urn:ietf:params:ppm:error:"):
 | unrecognizedTask        | An endpoint received a message with an unknown task ID. |
 | outdatedConfig          | The message was generated using an outdated configuration. |
 | batchInvalid            | A collect or aggregate-share request was made with invalid batch parameters. |
+| batchMismatch           | Aggregators disagree on the report shares that were aggregated in a batch. |
 
 This list is not exhaustive. The server MAY return errors set to a URI other
 than those defined above. Servers MUST NOT use the PPM URN namespace for errors

--- a/draft-gpew-priv-ppm.md
+++ b/draft-gpew-priv-ppm.md
@@ -811,8 +811,8 @@ enum {
 
 struct {
   Nonce nonce;
-  PrepareStepResult prepares_step_result;
-  select (PrepareStep.prepares_step_result) {
+  PrepareStepResult prepare_step_result;
+  select (PrepareStep.prepare_step_result) {
     case continued: opaque prep_msg<0..2^16-1>; // VDAF preparation message
     case finished:  Empty;
     case failed:    ReportShareError;

--- a/draft-gpew-priv-ppm.md
+++ b/draft-gpew-priv-ppm.md
@@ -1167,7 +1167,7 @@ After receiving the helper's response, the leader uses the HpkeCiphertext to
 respond to a collect request (see {{collect-flow}}).
 
 The leader MAY make multiple aggregate-share requests for a given batch interval
-and aggregation parameter MUST get the same result each time.
+and aggregation parameter and MUST get the same result each time.
 
 After issuing an aggregate-share request for a given batch interval, it is an
 error for the leader to issue any more aggregate or aggregate-init requests for

--- a/draft-gpew-priv-ppm.md
+++ b/draft-gpew-priv-ppm.md
@@ -737,7 +737,7 @@ each report into "report shares", one for each aggregator. The leader and helper
 run the aggregate initialization flow to accomplish two tasks:
 
 1. Recover and determine which input report shares are invalid.
-1. For each valid input report share, initialize the VDAF preparation process.
+1. For each valid report share, initialize the VDAF preparation process.
 
 An invalid report share is marked with one of the following errors:
 

--- a/draft-gpew-priv-ppm.md
+++ b/draft-gpew-priv-ppm.md
@@ -713,7 +713,7 @@ The aggregation flow can be thought of as having three phases:
   VDAF instance using these report shares and the public VDAF configured for
   the corresponding measurement task.
 - Continuation: Continue the aggregation flow by exchanging messages produced
-  by the underlying VDAF instance until aggregation completes or an error occurs.
+  by the underlying VDAF instance until aggregation completes or an error occurs. These messages do not replay the shares.
 - Completion: Finish the aggregate flow, yielding an aggregate share corresponding
   to all output shares in the batch.
 

--- a/draft-gpew-priv-ppm.md
+++ b/draft-gpew-priv-ppm.md
@@ -712,7 +712,8 @@ The aggregation flow can be thought of as having three phases:
   VDAF instance using these report shares and the VDAF configured for the
   corresponding measurement task.
 - Continuation: Continue the aggregation flow by exchanging messages produced
-  by the underlying VDAF instance until aggregation completes or an error occurs. These messages do not replay the shares.
+  by the underlying VDAF instance until aggregation completes or an error occurs.
+  These messages do not replay the shares.
 - Completion: Finish the aggregate flow, yielding an output share corresponding
   for each input report share in the batch.
 
@@ -722,13 +723,20 @@ aggregate output. That process is described in {{collect-flow}}.
 
 ### Aggregate Initialization {#agg-init}
 
-The leader begins aggregation by choosing a set of candidate reports that is subject to the following restrictions:
-* Each report in the set MUST pertain to the same PPM task.
-* It is an error to allow a report to be replayed. If the leader has already aggregated a report, but the report does not pertain to a batch that has been collected, then the report MUST be excluded.
-* It is an error to include a new report in a batch that has already been collected. If the report pertains to a batch that has been collected, but the leader has not yet aggregated the report, then it MUST be excluded.
+The leader begins aggregation by choosing a set of candidate reports that is subject
+to the following restrictions:
 
-After choosing the set of candidates, the The leader begins aggregation by splitting each report into "report
-shares", one for each aggregator. A single report share is encoded as follows:
+* Each report in the set MUST pertain to the same PPM task.
+* It is an error to allow a report to be replayed. If the leader has already aggregated
+  a report, but the report does not pertain to a batch that has been collected, then
+  the report MUST be excluded.
+* It is an error to include a new report in a batch that has already been collected.
+  If the report pertains to a batch that has been collected, but the leader has not yet
+  aggregated the report, then it MUST be excluded.
+
+After choosing the set of candidates, the The leader begins aggregation by splitting each
+report into "report shares", one for each aggregator. A single report share is encoded
+as follows:
 
 ~~~
 struct {

--- a/draft-gpew-priv-ppm.md
+++ b/draft-gpew-priv-ppm.md
@@ -721,20 +721,10 @@ each valid input report share into an output share:
 
 ### Aggregate Initialization {#agg-init}
 
-The leader begins aggregation by choosing a set of candidate reports that is subject
-to the following restrictions:
-
-* Each report in the set MUST pertain to the same PPM task.
-* It is an error to allow a report to be replayed. If the leader has already aggregated
-  a report, but the report does not pertain to a batch that has been collected, then
-  the report MUST be excluded.
-* It is an error to include a new report in a batch that has already been collected.
-  If the report pertains to a batch that has been collected, but the leader has not yet
-  aggregated the report, then it MUST be excluded.
-
-After choosing the set of candidates, the leader begins aggregation by splitting
-each report into "report shares", one for each aggregator. The leader and helpers then
-run the aggregate initialization flow to accomplish two tasks:
+The leader begins aggregation by choosing a set of candidate reports that pertain
+to the same PPM task. After choosing the set of candidates, the leader begins
+aggregation by splitting each report into "report shares", one for each aggregator.
+The leader and helpers then run the aggregate initialization flow to accomplish two tasks:
 
 1. Recover and determine which input report shares are invalid.
 1. For each valid report share, initialize the VDAF preparation process.
@@ -946,8 +936,8 @@ by the leader.
 
 #### Leader Continuation
 
-The leader begins each round of continuation for a report share based on its locally computed 
-prepare message and the previous PrepareShare from the helper. If PrepareShare is of type "failed", 
+The leader begins each round of continuation for a report share based on its locally computed
+prepare message and the previous PrepareShare from the helper. If PrepareShare is of type "failed",
 then the leader marks the report as failed and removes it from the candidate report set and does not
 process it further. If the type is "finished", then the leader aborts with "unrecognizedMessage".
 [[OPEN ISSUE: This behavior is not specified.]] If the type is "continued", then the leader proceeds as
@@ -1040,6 +1030,8 @@ then awaits the next message from the leader.
 [[OPEN ISSUE: consider relaxing this ordering constraint. See issue#217.]]
 
 ## Collecting Results {#collect-flow}
+
+
 
 The collector uses CollectReq to ask the leader to collect and return the
 results for a given PPM task over a given time period. To make a collect

--- a/draft-gpew-priv-ppm.md
+++ b/draft-gpew-priv-ppm.md
@@ -721,7 +721,8 @@ each valid input report share into an output share:
 ### Aggregate Initialization {#agg-init}
 
 The leader begins aggregation by choosing a set of candidate reports that pertain
-to the same PPM task. After choosing the set of candidates, the leader begins
+to the same PPM task. The leader can run this process for many candidate reports
+in parallel as needed. After choosing the set of candidates, the leader begins
 aggregation by splitting each report into "report shares", one for each aggregator.
 The leader and helpers then run the aggregate initialization flow to accomplish two tasks:
 
@@ -741,6 +742,8 @@ enum {
 } ReportShareError;
 ~~~
 
+The leader and helper initialization behavior is detailed below.
+
 #### Leader Initialization
 
 The leader begins the aggregate initialization phase with the set of candidate report
@@ -753,7 +756,8 @@ shares as follows:
 If any step yields an invalid report share, the leader removes the report share from
 the set of candidate reports. Once the leader has initialized this state for all valid
 candidate report shares, it then creates an AggregateInitReq message for each helper to
-initialize the preparation of this candidate set. This message is structured as follows:
+initialize the preparation of this candidate set. The AggregateInitReq message is
+structured as follows:
 
 ~~~
 struct {

--- a/draft-gpew-priv-ppm.md
+++ b/draft-gpew-priv-ppm.md
@@ -866,7 +866,7 @@ abort with error "unrecognizedMessage".
 #### Input Share Decryption {#input-share-decryption}
 
 Each report share has a corresponding task ID, nonce, list of extensions, and encrypted
-input report share. Let `nonce`, `extensions`, and `encrypted_input_share` denote these
+input share. Let `nonce`, `extensions`, and `encrypted_input_share` denote these
 values, respectively. Given these values, an aggregator decrypts the input report
 share as follows. First, the aggregator looks up the HPKE config and corresponding
 secret key indicated by `encrypted_input_share.config_id`. If not found, then it

--- a/draft-gpew-priv-ppm.md
+++ b/draft-gpew-priv-ppm.md
@@ -1019,8 +1019,8 @@ then awaits the next message from the leader.
 
 ### Aggregate Completion {#agg-complete}
 
-Once processing of a report share is finished, each aggregator stores the the
-recovered output shares until the batch to which it pertains is collected.
+Once processing of a report share is finished, each aggregator stores the
+recovered output share until the batch to which it pertains is collected.
 To aggregate the output shares, denoted `out_shares`, the aggregator runs
 the aggregation algorithm specified by the VDAF:
 

--- a/draft-gpew-priv-ppm.md
+++ b/draft-gpew-priv-ppm.md
@@ -379,7 +379,6 @@ in the "type" field (within the PPM URN namespace "urn:ietf:params:ppm:error:"):
 | unrecognizedTask        | An endpoint received a message with an unknown task ID. |
 | outdatedConfig          | The message was generated using an outdated configuration. |
 | batchInvalid            | A collect or aggregate-share request was made with invalid batch parameters. |
-| invalidReportShare      | The report share was invalid and could not be processed. |
 
 This list is not exhaustive. The server MAY return errors set to a URI other
 than those defined above. Servers MUST NOT use the PPM URN namespace for errors
@@ -1114,10 +1113,7 @@ struct {
 * `task_id` is the task ID associated with the PPM parameters.
 * `batch_interval` is the batch interval of the request.
 * `report_count` is the number of reports included in the aggregation.
-* `checksum` is the checksum computed over the set of client reports. The
-  checksum is computed by taking the SHA256 hash of each nonce from the client
-  reports included in the aggregation, then combining the hash values with a
-  bitwise-XOR operation.
+* `checksum` is the checksum computed over the set of client reports.
 * `helper_state` is the helper's state, which is carried across requests from
   the leader.
 

--- a/draft-gpew-priv-ppm.md
+++ b/draft-gpew-priv-ppm.md
@@ -850,7 +850,7 @@ The rest of the message is a sequence of PrepareShare values, the order of which
 matches that of the ReportShare values in `AggregateInitReq.report_shares`. Each report
 that was marked as invalid is assigned the PrepareResult `failed`. Otherwise, the
 PrepareShare is either marked as continued with the output `prep_msg`, or is marked
-as finished if the VDAF computation is finished.
+as finished if the VDAF preparation process is finished for the report share.
 
 The helper's response to the leader is an HTTP 200 OK whose body is the
 AggregateInitResp and media type is "message/ppm-aggregate-init-resp".

--- a/draft-gpew-priv-ppm.md
+++ b/draft-gpew-priv-ppm.md
@@ -1018,7 +1018,7 @@ struct {
 
 The order of AggregateContinueResp.process_shares matches that of the PrepareShare values in
 `AggregateContinueReq.process_shares`. The helper's response to the leader is an HTTP 200 OK whose body
-is the AggregateInitResp and media type is "message/ppm-aggregate-continue-resp". The helper
+is the AggregateContinueResp and media type is "message/ppm-aggregate-continue-resp". The helper
 then awaits the next message from the leader.
 
 ### Aggregate Completion {#agg-complete}

--- a/draft-gpew-priv-ppm.md
+++ b/draft-gpew-priv-ppm.md
@@ -920,9 +920,8 @@ out = VDAF.prep_next(prep_state, None)
 parameter. If either step fails, the aggregator marks the report as invalid with error
 `vdaf-prep-error`.
 
-Otherwise, the value `out` is interpreted as follows. If the VDAF is 0-round, then `out`
-is the aggregator's output share. Otherwise, if the VDAF consists of one round or more,
-then the aggregator interprets `out` as the pair `(prep_state, prep_msg)`.
+Otherwise, the value `out` is interpreted as follows. If this is the last round of the VDAF,
+then `out` is the aggregator's output share. Otherwise, `out` is the pair `(prep_state, prep_msg)`.
 
 ### Aggregate Continuation {#agg-continue-flow}
 

--- a/draft-gpew-priv-ppm.md
+++ b/draft-gpew-priv-ppm.md
@@ -1012,7 +1012,7 @@ and output message as follows:
 out = VDAF.prep_next(prep_state, inbound)
 ~~~
 
-where `inbound` is the previous VDAF message sent by the leader and `prep_state` is
+where `inbound` is the previous VDAF preapre message sent by the leader and `prep_state` is
 its current preparation state. If this operation fails, then the helper fails
 with error `vdaf-prep-error`. Otherwise, it interprets `out` as follows. If this
 is the last round of VDAF preparation phase, then `out` is the helper's output

--- a/draft-gpew-priv-ppm.md
+++ b/draft-gpew-priv-ppm.md
@@ -999,7 +999,7 @@ with error `vdaf-prep-error`. Otherwise, it interprets `out` as follows. If this
 is the last round of VDAF preparation phase, then `out` is the helper's output
 share, in which case the helper finishes and transitions to FINISHED. Otherwise,
 the helper interpets `out` as the tuple `(new_state, agg_msg)`, where
-`new_state` is its updated preperation state and `agg_msg` is its next VDAF
+`new_state` is its updated preparation state and `agg_msg` is its next VDAF
 message.
 
 This output message for each report in AggregateContinueReq.seq is then sent to the leader

--- a/draft-gpew-priv-ppm.md
+++ b/draft-gpew-priv-ppm.md
@@ -867,7 +867,7 @@ abort with error "unrecognizedMessage".
 
 Each report share has a corresponding task ID, nonce, list of extensions, and encrypted
 input share. Let `nonce`, `extensions`, and `encrypted_input_share` denote these
-values, respectively. Given these values, an aggregator decrypts the input report
+values, respectively. Given these values, an aggregator decrypts the input
 share as follows. First, the aggregator looks up the HPKE config and corresponding
 secret key indicated by `encrypted_input_share.config_id`. If not found, then it
 marks the report share as invalid. Otherwise, it decrypts the payload with the

--- a/draft-gpew-priv-ppm.md
+++ b/draft-gpew-priv-ppm.md
@@ -945,14 +945,15 @@ by the leader.
 
 #### Leader Continuation
 
-The leader begins each round of continuation for a report share based on a previous
-response from the helper, denoted `helper_outbound`, and a previous message produced
-from the leader, denoted `leader_outbound`. Each helper message carries a PrepareResult,
-indicating if preparation for the report share should continue, has failed, or is finished.
+The leader begins each round of continuation for a report share based on its locally computed 
+prepare message and the previous PrepareShare from the helper. If PrepareShare is of type "failed", 
+then the leader marks the report as failed and removes it from the candidate report set and does not
+process it further. If the type is "finished", then the leader aborts with "unrecognizedMessage".
+[[OPEN ISSUE: This behavior is not specified.]] If the type is "continued", then the leader proceeds as
+follows.
 
-If the helper message failed, then the leadaer marks the report as failed and removes it
-from the candidate report set and does not process it further. Otherwise, the leader
-computes its next state transition as follows:
+Let `leader_outbound` denote the leader's prepare message and `helper_outbound` denote the
+helper's. The leader computes the next state transition as follows:
 
 ~~~
 inbound = VDAF.prep_shares_to_prep(agg_param, [leader_outbound, helper_outbound])

--- a/draft-gpew-priv-ppm.md
+++ b/draft-gpew-priv-ppm.md
@@ -1231,13 +1231,14 @@ as follows:
 
 ~~~
 enc, context = SetupBaseS(pk, AggregateShareReq.task_id ||
-                              "ppm-00 aggregate share" || 0x03 || 0x00)
+                              "ppm-00 aggregate share" || server_role || 0x00)
 
 encrypted_agg_share = context.Seal(AggregateShareReq.batch_interval,
                                    agg_share)
 ~~~
 
-where `pk` is the HPKE public key encoded by the collector's HPKE key.
+where `pk` is the HPKE public key encoded by the collector's HPKE key,
+and server_role is is `0x02` for the leader and `0x03` for a helper.
 
 The collector decrypts these aggregate shares using the opposite process.
 Specifically, given an encrypted input share, denoted `enc_share`, for a

--- a/draft-gpew-priv-ppm.md
+++ b/draft-gpew-priv-ppm.md
@@ -648,7 +648,7 @@ information specific to the extension.
 
 ### Leader State {#leader-state}
 
-The leader is required to buffer reports while waiting to aggregate them. The
+The leader MUST buffer reports while waiting to aggregate them. The
 leader SHOULD NOT accept reports whose timestamps are too far in the future.
 Implementors MAY provide for some small leeway, usually no more than a few
 minutes, to account for clock skew.

--- a/draft-gpew-priv-ppm.md
+++ b/draft-gpew-priv-ppm.md
@@ -1198,9 +1198,6 @@ computed above and `encrypted_aggregate_share.ciphertext` is the ciphertext
 After receiving the helper's response, the leader uses the HpkeCiphertext to
 respond to a collect request (see {{collect-flow}}).
 
-The leader MAY make multiple aggregate-share requests for a given batch interval
-and aggregation parameter and MUST get the same result each time.
-
 After issuing an aggregate-share request for a given batch interval, it is an
 error for the leader to issue any more aggregate or aggregate-init requests for
 additional reports in the batch interval. These reports will be rejected by helpers as

--- a/draft-gpew-priv-ppm.md
+++ b/draft-gpew-priv-ppm.md
@@ -1036,7 +1036,7 @@ The order of AggregateContinueResp.prepare_shares matches that of the PrepareSha
 is the AggregateContinueResp and media type is "message/ppm-aggregate-continue-resp". The helper
 then awaits the next message from the leader.
 
-[[OPEN ISSUE: consider relaxing this ordering constraint]]
+[[OPEN ISSUE: consider relaxing this ordering constraint. See issue#217.]]
 
 ## Collecting Results {#collect-flow}
 

--- a/draft-gpew-priv-ppm.md
+++ b/draft-gpew-priv-ppm.md
@@ -773,10 +773,10 @@ struct {
 The `nonce` and `extensions` fields of each ReportShare match that in the Report
 uploaded by the client. The `encrypted_input_share` field is the `HpkeCiphertext`
 whose index in `Report.encrypted_input_shares` is equal to the index of the aggregator
-in the task's `aggregator_endpoints`. The `agg_param` field is an opaque, VDAF-specific
-aggregation parameter. The `helper_state` parameter contains the helper's state.
-This is an optional parameter of an aggregate request that the helper can use to carry
-state across requests and across aggregate flows.
+in the task's `aggregator_endpoints` to which the AggregateInitReq is being sent.
+The `agg_param` field is an opaque, VDAF-specific aggregation parameter. The
+`helper_state` parameter contains the helper's state. This is an optional parameter
+of an aggregate request that the helper can use to carry state across requests and across aggregate flows.
 
 Let `[aggregator]` denote the helper's API endpoint. The leader sends a POST
 request to `[aggregator]/aggregate` with its AggregateInitReq message as

--- a/draft-gpew-priv-ppm.md
+++ b/draft-gpew-priv-ppm.md
@@ -786,7 +786,7 @@ the payload. The media type is "message/ppm-aggregate-init-req".
 Each helper begins their portion of the aggregate initialization phase with the set
 of candidate report shares obtained in an `AggregateInitReq` message from the leader.
 It attempts to recover and validate the corresponding input shares similar to the leader,
-and eventually returns a response to the leader carrying the preparation state for each
+and eventually returns a response to the leader carrying a VDAF-specific message for each
 report share.
 
 To begin this process, the helper first checks that the nonces in `AggregateInitReq.report_shares`

--- a/draft-gpew-priv-ppm.md
+++ b/draft-gpew-priv-ppm.md
@@ -709,12 +709,12 @@ The aggregation flow can be thought of as having three phases:
 
 - Initialization: Begin the aggregation flow by sharing report shares with each
   helper. Each aggregator, including the leader, initializates the underlying
-  VDAF instance using these report shares and the public VDAF configured for
-  the corresponding measurement task.
+  VDAF instance using these report shares and the VDAF configured for the
+  corresponding measurement task.
 - Continuation: Continue the aggregation flow by exchanging messages produced
   by the underlying VDAF instance until aggregation completes or an error occurs. These messages do not replay the shares.
-- Completion: Finish the aggregate flow, yielding an aggregate share corresponding
-  to all output shares in the batch.
+- Completion: Finish the aggregate flow, yielding an output share corresponding
+  for each input report share in the batch.
 
 Once both aggregation is complete and a sufficient number of reports have
 been aggregated, the aggregate shares can be collected to produce the final,

--- a/draft-gpew-priv-ppm.md
+++ b/draft-gpew-priv-ppm.md
@@ -774,6 +774,8 @@ struct {
 } AggregateInitReq;
 ~~~
 
+[[OPEN ISSUE: consider sending report shares separately (in parallel) to the aggregate instructions. RIght now, aggregation parameters and the corresponding report shares are sent at the same time, but this may not be strictly necessary. ]]
+
 The `nonce` and `extensions` fields of each ReportShare match that in the Report
 uploaded by the client. The `encrypted_input_share` field is the `HpkeCiphertext`
 whose index in `Report.encrypted_input_shares` is equal to the index of the aggregator

--- a/draft-gpew-priv-ppm.md
+++ b/draft-gpew-priv-ppm.md
@@ -1001,7 +1001,7 @@ out = VDAF.prep_next(prep_state, inbound)
 ~~~
 
 where `inbound` is the previous VDAF preapre message sent by the leader and `prep_state` is
-its current preparation state. If this operation fails, then the helper fails
+the helper's current preparation state. If this operation fails, then the helper fails
 with error `vdaf-prep-error`. Otherwise, it interprets `out` as follows. If this
 is the last round of VDAF preparation phase, then `out` is the helper's output
 share, in which case the helper stores the output share for future collection.

--- a/draft-gpew-priv-ppm.md
+++ b/draft-gpew-priv-ppm.md
@@ -796,7 +796,7 @@ the payload. The media type is "message/ppm-aggregate-init-req".
 #### Helper Initialization
 
 Each helper begins their portion of the aggregate initialization phase with the set
-of candidate report shares obtained in a `AggregateInitReq` message from the leader.
+of candidate report shares obtained in an `AggregateInitReq` message from the leader.
 It attempts to recover and validate the corresponding input shares similar to the leader,
 and eventually returns a response to the leader carrying the preparation state for each
 report share.
@@ -826,7 +826,7 @@ struct {
   PrepareResult prepare_result;
   select (PrepareShare.prepare_result) {
     case continued: opaque prep_msg<0..2^16-1>; // VDAF preparation message
-    case finished:  // empty
+    case finished:  Empty;
     case failed:    ReportShareError;
   }
 } PrepareShare;
@@ -875,14 +875,15 @@ following procedure:
 
 ~~~
 context = SetupBaseR(encrypted_input_share.enc, sk, task_id ||
-                     "ppm-00 input share" || 0x01 || 0x02)
+                     "ppm-00 input share" || 0x01 || server_role)
 
 input_share = context.Open(nonce || extensions,
                            encrypted_input_share.payload)
 ~~~
 
-where `sk` is the HPKE secret key, `task_id` is the task ID, and `nonce` and
-`extensions` are the nonce and extensions of the report share respectively.
+where `sk` is the HPKE secret key, `task_id` is the task ID, `nonce` and
+`extensions` are the nonce and extensions of the report share respectively,
+and `server_role` is 0x02 if the aggregator is the leader and 0x03 otherwise.
 If decryption fails, the aggregator marks the report share as invalid. Otherwise,
 it outputs the resulting `input_share`.
 

--- a/draft-gpew-priv-ppm.md
+++ b/draft-gpew-priv-ppm.md
@@ -803,6 +803,8 @@ input share in `AggregateInitReq.report_shares` as follows:
 1. Check that the resulting input share is valid as described in {{input-share-batch-validation}}.
 1. Initialize VDAF preparation and initial outputs as described in {{input-share-prep}}.
 
+[[OPEN ISSUE: consider moving the helper nonce check into #input-share-batch-validation]]
+
 Once the helper has processed each valid report share in `AggregateInitReq.report_shares`, the
 helper then creates an AggregateInitResp message to complete its initialization. This message is
 structured as follows:

--- a/draft-gpew-priv-ppm.md
+++ b/draft-gpew-priv-ppm.md
@@ -761,7 +761,7 @@ shares as follows:
 1. Check that the resulting input share is valid as described in {{input-share-batch-validation}}.
 1. Initialize VDAF preparation as described in {{input-share-prep}}.
 
-If any step yields yields an invalid report share, the leader removes the report share from
+If any step yields an invalid report share, the leader removes the report share from
 the set of candidate reports. Once the leader has initialized this state for all valid
 candidate report shares, it then creates an AggregateInitReq message for each helper to
 initialize the preparation of this candidate set. This message is structured as follows:


### PR DESCRIPTION
This wires up PPM to drive the underlying VDAF state machine for individual reports. It splits the aggregate flow into three phases: initialization, progression (where the aggregators exchange messages to perform validation), and finalization. It also moves the process of fetching the aggregate share value for each aggregator to the collect flow, since that seems more closely aligned with the process of collection than it is about aggregation.

Open question (there may be more): Can we come up with a better name than `Process` for the message that conveys VDAF intermediate results?